### PR TITLE
Update installation instructions to use --pre. Bump to release 1.0b2

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,6 +1,6 @@
 # PyEQSP: Python Equal Area Sphere Partitioning Library
 
-**Release 1.0b1** (2026-04-21): Copyright 2026 Paul Leopardi
+**Release 1.0b2** (2026-06-07): Copyright 2026 Paul Leopardi
 
 # Authors and Acknowledgements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0b2] - 2026-06-07
+**Git Tag**: `release_1_0b2` | **Distribution**: `PyPI / GitHub`
+
+### Added
+- **Accumulating Changes**: Initial commit for the 1.0b2 release cycle.
+- **Maintenance Guide**: Formalized the "Technical Rationale" for the Defense in Depth strategy in `doc/maintenance_guide.md`, detailing the local/remote distinction for Git hooks and credential security.
+
+### Changed
+- **Metadata Synchronization**: Bumped project version to `1.0b2`.
+- **Installation Instructions**: Updated `INSTALL.md` and `doc/user/installation.md` to explicitly direct users to use the `--pre` flag for pip installations during the pre-release phase (Issue #30).
+
+
 ## [1.0b1] - 2026-04-21
 **Git Tag**: `release_1_0b1` | **Distribution**: `PyPI / GitHub`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to PyEQSP
 
-**Release 1.0b1** (2026-04-21): Copyright 2026 Paul Leopardi
+**Release 1.0b2** (2026-06-07): Copyright 2026 Paul Leopardi
 
 Thank you for helping us refine the Recursive Zonal Equal Area Sphere Partitioning (**PyEQSP**) library! This project is currently in Beta testing, and your feedback is invaluable.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -96,7 +96,7 @@ pre-commit install
 
 ## 2. Installation via Pip
 
-Because **PyEQSP** is currently in beta (pre-release status), you must specify the `--pre` flag to install it from PyPI:
+Because the current PyPI releases of **PyEQSP** are beta pre-releases, install with the `--pre` flag (this will not be necessary once a stable 1.0.0+ release is published):
 
 ```bash
 pip install --pre pyeqsp

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # PyEQSP: Python Equal Area Sphere Partitioning Library
 
-**Release 1.0b1** (2026-04-21): Copyright 2026 Paul Leopardi
+**Release 1.0b2** (2026-06-07): Copyright 2026 Paul Leopardi
 
 # Installation
 
@@ -96,21 +96,16 @@ pre-commit install
 
 ## 2. Installation via Pip
 
-If the package is available on PyPI or a package repository, you
-can install it directly:
+Because **PyEQSP** is currently in beta (pre-release status), you must specify the `--pre` flag to install it from PyPI:
 
 ```bash
-pip install pyeqsp
+pip install --pre pyeqsp
 ```
-
-> **Note:** **PyEQSP 1.0b1** is the first public Open Beta release available on **PyPI**.
-> While stabilized for research use, users should expect a "pre-release" status.
-> Version 1.0.0 will be the first stable, non-beta release.
 
 To upgrade an existing installation:
 
 ```bash
-pip install --upgrade pyeqsp
+pip install --upgrade --pre pyeqsp
 ```
 
 ## Verification

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PyEQSP: Python Equal Area Sphere Partitioning Library
 
-**Release 1.0b1** (2026-04-21): Copyright 2026 Paul Leopardi
+**Release 1.0b2** (2026-06-07): Copyright 2026 Paul Leopardi
 
 PyEQSP is a Python library that implements the **Recursive Zonal Equal Area (EQ) Sphere Partitioning** algorithm, originally developed as a Matlab toolbox by Paul Leopardi.
 
@@ -8,7 +8,7 @@ An **EQ partition** divides Sᵈ (the unit sphere in ℝ<sup>d+1</sup>) into a f
 
 > **Naming Distinction**: While the project and GitHub repository share the name **PyEQSP** (or **pyeqsp** on PyPI), you import the package as **eqsp**.
 
-Release **1.0b1** achieves **100% project-wide coverage** for both the core library and the entire maintenance ecosystem.
+Release **1.0b2** achieves **100% project-wide coverage** for both the core library and the entire maintenance ecosystem.
 
 The **diameter** of a region is the maximum distance between any two of its points (formally the supremum of the Euclidean distance). EQ partitions produce regions with small diameter; specifically, there exists a constant C(d) such that the greatest diameter for an N-region partition of Sᵈ is bounded by C(d)·N<sup>-1/d</sup>.
 
@@ -29,6 +29,8 @@ including:
 - Computer graphics and rendering
 
 ## Documentation
+
+The full documentation for PyEQSP is available at **[Read the Docs](https://pyeqsp.readthedocs.io/en/latest/)** and mirrored at **[SourceForge](http://eqsp.sourceforge.net)**.
 
 For a comprehensive overview, including mathematical background, detailed tutorials, and advanced use cases, please consult the [User Guide](doc/user_guide.md) and [Core Concepts](doc/user/core_concepts.md).
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -64,6 +64,10 @@ intersphinx_mapping = {
     "matplotlib": ("https://matplotlib.org/stable", None),
 }
 
+# Disable Intersphinx in offline/sandbox environments to prevent network warnings
+if os.environ.get("OFFLINE") == "1":
+    intersphinx_mapping = {}
+
 # Nitpick ignore patterns for common scientific docstring labels
 # that aren't real classes.
 nitpick_ignore = [

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -64,8 +64,8 @@ intersphinx_mapping = {
     "matplotlib": ("https://matplotlib.org/stable", None),
 }
 
-# Disable Intersphinx in offline/sandbox environments to prevent network warnings
-if os.environ.get("OFFLINE") == "1":
+# Disable Intersphinx in offline environments to prevent network warnings
+if os.environ.get("PYEQSP_OFFLINE") == "1":
     intersphinx_mapping = {}
 
 # Nitpick ignore patterns for common scientific docstring labels

--- a/doc/maintainer/release_notes.md
+++ b/doc/maintainer/release_notes.md
@@ -1,5 +1,23 @@
 # Appendix G: Historical Release Notes
 
+## 1.0b2
+**2026-06-07**
+
+Release **1.0b2** is a continuation of the Open Beta phase, accumulating fixes and refinements from community feedback.
+
+### Key Changes
+- **Metadata Sync**: Bumped project version to `1.0b2` and synchronized version counters across all documentation and project headers.
+- **Installation Instructions**: Updated installation documentation (`INSTALL.md` and `doc/user/installation.md`) to explicitly guide users to use the `--pre` flag for pip installations during pre-release phases (Issue #30).
+- **Maintenance Guide**: Formalized the "Technical Rationale" for the Defense in Depth strategy in `doc/maintenance_guide.md`, detailing the local/remote distinction for Git hooks and credential security.
+
+### Release Metadata
+- **Version**: 1.0b2
+- **Tag**: `release_1_0b2`
+- **Distribution**: PyPI / GitHub
+- **Verification**: [PASSED] 100% Project-wide Coverage, 0 Ruff errors, 0 Sphinx warnings.
+
+---
+
 This document tracks the internal evolution of the PyEQSP maintenance ecosystem, including changes to CI/CD pipelines, release scripts, and historical quality metrics. For user-facing feature changes, see the [CHANGELOG.md](https://github.com/penguian/pyeqsp/blob/main/CHANGELOG.md).
 
 ## 1.0b1

--- a/doc/maintainer/release_roadmap.md
+++ b/doc/maintainer/release_roadmap.md
@@ -86,6 +86,12 @@ This roadmap outlines the development phases from the initial beta through the 1
 - [x] **Enhanced Issue Routing**: Clearly partitioned detailed bug reports from general beta testing observations.
 - [x] **Portability Audit**: Added explicit POSIX/Linux caveats for the maintenance environment.
 - [x] **Metadata Sync**: Formally bumped project status to `Development Status :: 4 - Beta` and synchronized version counters (1.0b1).
+### 1.0b2 Open Beta: Accumulating Refinements
+**Released: 2026-06-07** | **Git Tag: release_1_0b2** | **Distribution: PyPI / GitHub**
+
+- [x] **Metadata Sync**: Bumped project version to `1.0b2` and synchronized version counters across all documentation and project headers.
+- [x] **Maintenance Guide Expansion**: Formalize the "Technical Rationale" for the Defense in Depth strategy, detailing the local/remote distinction for Git hooks and security implications.
+- [x] **Accumulating Changes**: Track community feedback and bug fixes for the next beta release.
 
 ### 1.0 General Release [PLANNED]
 

--- a/doc/maintainer/technical_symmetry.md
+++ b/doc/maintainer/technical_symmetry.md
@@ -39,7 +39,7 @@ PyEQSP's recursive partitioning uses a `_private` cache for $S^{d-1}$ partitions
 To maintain polymorphic compatibility, all property functions must accept `even_collars`, even if the property (like total area error) is parity-invariant. This ensures call-site stability for users while allowing internal mathematics to exploit symmetry when available.
 For foundational citations, see the Volume 2 [References](references_vol2.md).
 
-## Audit Summary (PyEQSP 1.0b1 Beta)
+## Audit Summary (PyEQSP 1.0b2 Beta)
 
 - **Derivation Alignment**: The `even_collars` algebraic derivation structurally mirrors the runtime calculation in `eq_caps()` (`eqsp/partitions.py`).
 - **Cache Integrity**: The $n_{\text{collars}}/2$ cache boundary correctly mirrors collar $k$ to $n_{\text{collars}} - k + 1$ ensuring 100% cache utilization for $S^3$ southern hemisphere regions.

--- a/doc/maintenance_guide.md
+++ b/doc/maintenance_guide.md
@@ -75,6 +75,15 @@ PyEQSP employs a three-tier **"Defense in Depth"** strategy to ensure project-wi
 
 This layered approach is complemented by **Project-Specific Guardrails** that enforce research integrity (e.g., bibliographic consistency, manifold naming, and positional-only argument audits).
 
+#### Technical Rationale: Local vs. Remote Hooks and Security Implications
+
+The distinction between local and remote verification is fundamental to securing the release lifecycle and preserving repository integrity:
+
+1.  **Local Pre-commit Hooks (Layer 1)**: Executed client-side, these hooks catch simple syntax, style, and formatting issues early. However, they are not security boundaries; developers can bypass local hooks (e.g., using `git commit --no-verify`), and local environments can be inconsistent (e.g., different dependency versions or local system configurations).
+2.  **Authoritative Remote CI (Layer 3)**: Executed in a standardized, isolated virtual environment, the CI pipeline acts as the final gatekeeper. Because the CI configuration is checked into version control, it cannot be bypassed, and it ensures uniform environment execution.
+3.  **Security Boundaries and Production Credentials**: Crucially, production credentials and API keys (such as PyPI tokens or SourceForge SSH keys) are never exposed to local hooks or arbitrary PR runners. Local scripts (like `upload_sourceforge.py` and `upload_release.py`) are deliberately designed to run on a maintainer's local machine using local credentials or prompts, ensuring that secrets never propagate to or reside in the shared remote CI environment.
+
+
 ### Maintenance Scripts Inventory
 
 | Script | Location | Purpose |

--- a/doc/user/installation.md
+++ b/doc/user/installation.md
@@ -6,7 +6,7 @@ PyEQSP requires Python 3.11 or later. We recommend using a virtual environment t
 
 ## Basic Installation
 
-The easiest way to install **PyEQSP** is via `pip` from PyPI. Because PyEQSP is currently in beta (pre-release status), you must specify the `--pre` flag:
+The easiest way to install **PyEQSP** is via `pip` from PyPI. Because the current PyPI releases are beta pre-releases, you must specify the `--pre` flag:
 
 ```bash
 pip install --pre pyeqsp

--- a/doc/user/installation.md
+++ b/doc/user/installation.md
@@ -6,16 +6,16 @@ PyEQSP requires Python 3.11 or later. We recommend using a virtual environment t
 
 ## Basic Installation
 
-The easiest way to install **PyEQSP** is via `pip` from PyPI:
+The easiest way to install **PyEQSP** is via `pip` from PyPI. Because PyEQSP is currently in beta (pre-release status), you must specify the `--pre` flag:
 
 ```bash
-pip install pyeqsp
+pip install --pre pyeqsp
 ```
 
 To install with development and testing dependencies (recommended for reproducing research):
 
 ```bash
-pip install "pyeqsp[dev]"
+pip install --pre "pyeqsp[dev]"
 ```
 
 ## Creating a Virtual Environment
@@ -30,7 +30,7 @@ python3 -m venv .venvs/.venv
 source .venvs/.venv/bin/activate
 
 # Install PyEQSP in the environment
-pip install pyeqsp
+pip install --pre pyeqsp
 ```
 
 (venv-sys-setup)=

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyeqsp"
-version = "1.0b1"
+version = "1.0b2"
 description = "Python Equal Area Sphere Partitioning Library"
 readme = "README.md"
 authors = [

--- a/release/build_dist.py
+++ b/release/build_dist.py
@@ -11,8 +11,9 @@ Orchestrates the clean-build-check cycle for PyEQSP distribution.
 Exits non-zero if any step fails.
 
 Environment Variables:
-    PYEQSP_OFFLINE: Set to "1" to build offline. This appends "--no-isolation"
-                    to prevent `build` from attempting to download dependencies.
+    PYEQSP_OFFLINE: Set to "1" to disable build isolation (adds "--no-isolation").
+                    Useful in offline/air-gapped environments to avoid
+                    `build` attempting to download build dependencies.
 
 Usage:
     python release/build_dist.py

--- a/release/build_dist.py
+++ b/release/build_dist.py
@@ -10,6 +10,10 @@ Orchestrates the clean-build-check cycle for PyEQSP distribution.
 
 Exits non-zero if any step fails.
 
+Environment Variables:
+    PYEQSP_OFFLINE: Set to "1" to build offline. This appends "--no-isolation"
+                    to prevent `build` from attempting to download dependencies.
+
 Usage:
     python release/build_dist.py
 """
@@ -99,7 +103,8 @@ def main():
     try:
         try:
             build_cmd = [sys.executable, "-m", "build"]
-            if os.environ.get("OFFLINE") == "1":
+            if os.environ.get("PYEQSP_OFFLINE") == "1":
+                # Disable isolation when offline to prevent download attempts
                 build_cmd.append("--no-isolation")
             run_command(build_cmd, "Building distribution")
         except (Exception, SystemExit):  # pragma: no cover

--- a/release/build_dist.py
+++ b/release/build_dist.py
@@ -98,7 +98,10 @@ def main():
 
     try:
         try:
-            run_command([sys.executable, "-m", "build"], "Building distribution")
+            build_cmd = [sys.executable, "-m", "build"]
+            if os.environ.get("OFFLINE") == "1":
+                build_cmd.append("--no-isolation")
+            run_command(build_cmd, "Building distribution")
         except (Exception, SystemExit):  # pragma: no cover
             if not args.keep_on_fail:  # pragma: no cover
                 print(

--- a/validation/verify_all.py
+++ b/validation/verify_all.py
@@ -21,6 +21,7 @@ import os
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -157,6 +158,10 @@ def main():
         )
         print("[DONE] Uninstallation attempted.\n")
 
+    sphinx_build_dir = "_build"
+    if not os.access(str(REPO_ROOT / "doc"), os.W_OK):
+        sphinx_build_dir = os.path.join(tempfile.gettempdir(), "pyeqsp_doc_build")
+
     steps = [
         (
             [
@@ -199,9 +204,25 @@ def main():
             [py, "validation/quality_check.py"],
             "Performance Quality Check",
         ),
-        (["make", "-C", "doc", "doctest"], "Sphinx Doctest"),
         (
-            ["make", "-C", "doc", "html", "SPHINXOPTS=-W"],
+            [
+                "make",
+                "-C",
+                "doc",
+                "doctest",
+                f"BUILDDIR={sphinx_build_dir}",
+            ],
+            "Sphinx Doctest",
+        ),
+        (
+            [
+                "make",
+                "-C",
+                "doc",
+                "html",
+                f"BUILDDIR={sphinx_build_dir}",
+                "SPHINXOPTS=-W",
+            ],
             "Sphinx HTML Build (Zero Warning Policy)",
         ),
         (

--- a/validation/verify_all.py
+++ b/validation/verify_all.py
@@ -21,7 +21,6 @@ import os
 import shutil
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -158,10 +157,6 @@ def main():
         )
         print("[DONE] Uninstallation attempted.\n")
 
-    sphinx_build_dir = "_build"
-    if not os.access(str(REPO_ROOT / "doc"), os.W_OK):
-        sphinx_build_dir = os.path.join(tempfile.gettempdir(), "pyeqsp_doc_build")
-
     steps = [
         (
             [
@@ -204,25 +199,9 @@ def main():
             [py, "validation/quality_check.py"],
             "Performance Quality Check",
         ),
+        (["make", "-C", "doc", "doctest"], "Sphinx Doctest"),
         (
-            [
-                "make",
-                "-C",
-                "doc",
-                "doctest",
-                f"BUILDDIR={sphinx_build_dir}",
-            ],
-            "Sphinx Doctest",
-        ),
-        (
-            [
-                "make",
-                "-C",
-                "doc",
-                "html",
-                f"BUILDDIR={sphinx_build_dir}",
-                "SPHINXOPTS=-W",
-            ],
+            ["make", "-C", "doc", "html", "SPHINXOPTS=-W"],
             "Sphinx HTML Build (Zero Warning Policy)",
         ),
         (


### PR DESCRIPTION
Closes #30 and #29

This pull request prepares the PyEQSP 1.0b2 beta release by synchronizing version metadata across the project, updating installation documentation to use `pip install --pre,` and adding “offline mode” behavior for` build/docs` tooling.

### Changes:

* Bump package version to `1.0b2` and sync release labels/dates across key docs.
* Update pip installation instructions to use `--pre` for pre-release availability on PyPI.
* Add `PYEQSP_OFFLINE=1` support to reduce network-dependent behavior in release builds and Sphinx intersphinx.